### PR TITLE
People form updating

### DIFF
--- a/src/components/forms/PeopleForm.js
+++ b/src/components/forms/PeopleForm.js
@@ -83,7 +83,7 @@ const PeopleForm = ({ onSubmit }) => {
 				</Col>
 				<Col span={12}>
 					<Form.Item label='Phone number' name='phone'>
-						<Input type='number' placeholder='Enter phone number' />
+						<Input placeholder='Enter phone number' />
 					</Form.Item>
 				</Col>
 			</Row>

--- a/src/components/forms/PeopleForm.js
+++ b/src/components/forms/PeopleForm.js
@@ -31,8 +31,6 @@ const PeopleForm = ({ onSubmit }) => {
 	] = Form.useForm();
 
 	if (!loading && data) {
-		console.log('person being edited', data.person);
-
 		form.setFieldsValue(data.person);
 	}
 

--- a/src/components/forms/PeopleForm.js
+++ b/src/components/forms/PeopleForm.js
@@ -23,7 +23,7 @@ const PeopleForm = ({ onSubmit }) => {
 
 	const submitForm = values => {
 		setSubmitted(true);
-		onSubmit(values);
+		onSubmit(values, params.id);
 	};
 
 	const [

--- a/src/components/graphql/cache/index.js
+++ b/src/components/graphql/cache/index.js
@@ -1,7 +1,9 @@
+import updateAfterPersonCreate from './updateAfterPersonCreate';
 import updateAfterPersonChange from './updateAfterPersonChange';
 import updateAfterPersonDelete from './updateAfterPersonDelete';
 
 export {
+    updateAfterPersonCreate,
     updateAfterPersonChange,
     updateAfterPersonDelete
 };

--- a/src/components/graphql/cache/index.js
+++ b/src/components/graphql/cache/index.js
@@ -1,0 +1,7 @@
+import updateAfterPersonChange from './updateAfterPersonChange';
+import updateAfterPersonDelete from './updateAfterPersonDelete';
+
+export {
+    updateAfterPersonChange,
+    updateAfterPersonDelete
+};

--- a/src/components/graphql/cache/updateAfterPersonChange.js
+++ b/src/components/graphql/cache/updateAfterPersonChange.js
@@ -1,0 +1,20 @@
+import { ALL_PERSONS } from '../queries';
+/**
+ * Updates the cache after a person has been updated
+ */
+export default function(cache, { data: { updatePerson } }) {
+    // read ALL_PERSONS
+    const allPersons = cache.readQuery({ query: ALL_PERSONS });
+    // write update to the cache
+    cache.writeQuery({
+        query: ALL_PERSONS,
+        data: { persons: allPersons.persons.map(person => {
+            // find the person that was updated and
+            // update the cache,
+            if(person.id === updatePerson.id) {
+                return { ...person, ...updatePerson };
+            }
+            return person;
+        }) }
+    });
+}

--- a/src/components/graphql/cache/updateAfterPersonCreate.js
+++ b/src/components/graphql/cache/updateAfterPersonCreate.js
@@ -1,0 +1,13 @@
+import { ALL_PERSONS } from '../queries';
+/**
+ * Updates the cache after a person has been created
+ */
+export default function(cache, { data: { createPerson } }) {
+    // read ALL_PERSONS
+    const allPersons = cache.readQuery({ query: ALL_PERSONS });
+    // write creation to the cache
+    cache.writeQuery({
+        query: ALL_PERSONS,
+        data: { persons: [ ...allPersons.persons, createPerson ] }
+    });
+}

--- a/src/components/graphql/cache/updateAfterPersonDelete.js
+++ b/src/components/graphql/cache/updateAfterPersonDelete.js
@@ -1,0 +1,14 @@
+import { ALL_PERSONS } from '../queries';
+/**
+ * Updates the cache after a person has been deleted
+ */
+export default function(cache, { data: { deletePerson } }) {
+    // read ALL_PERSONS
+    const allPersons = cache.readQuery({ query: ALL_PERSONS });
+
+    // write delete to the cache
+    cache.writeQuery({
+        query : ALL_PERSONS,
+        data  : { persons: allPersons.persons.filter(person => person.id !== deletePerson.id) },
+    });
+}

--- a/src/components/graphql/mutations.js
+++ b/src/components/graphql/mutations.js
@@ -21,6 +21,7 @@ export const CREATE_PERSON = gql`
 export const UPDATE_PERSON = gql`
 	mutation updatePerson($id: ID!, $updates: PersonUpdateInput!) {
 		updatePerson(data: $updates, where: { id: $id }) {
+			id
 			date_created
 			first_name
 			last_name

--- a/src/components/graphql/mutations.js
+++ b/src/components/graphql/mutations.js
@@ -18,6 +18,23 @@ export const CREATE_PERSON = gql`
 	}
 `;
 
+export const UPDATE_PERSON = gql`
+	mutation updatePerson($id: ID!, $updates: PersonUpdateInput!) {
+		updatePerson(data: $updates, where: { id: $id }) {
+			date_created
+			first_name
+			last_name
+			email
+			phone
+			address
+			address2
+			city
+			state
+			zip
+		}
+	}
+`;
+
 export const DELETE_PERSON = gql`
 	mutation deletePerson($id: ID!) {
 		deletePerson(where: { id: $id }) {

--- a/src/components/pages/People.js
+++ b/src/components/pages/People.js
@@ -19,12 +19,31 @@ const People = () => {
 
 	const [ 
 		updatePerson,
-	] = useMutation(UPDATE_PERSON);
+	] = useMutation(UPDATE_PERSON, {
+		// when an update is performed, update the cache
+		update(cache, { data: { updatePerson } }) {
+			// read ALL_PERSONS
+			const allPersons = cache.readQuery({ query: ALL_PERSONS });
+			console.log('updatePerson', updatePerson);
+			// write update to the cache
+			cache.writeQuery({
+				query: ALL_PERSONS,
+				data: { persons: allPersons.persons.map(person => {
+					// find the person that was updated and
+					// update the cache,
+					if(person.id === updatePerson.id) {
+						return { ...person, ...updatePerson };
+					}
+					return person;
+				}) }
+			});
+		}
+	});
 
 	const [
 		deletePerson,
 	] = useMutation(DELETE_PERSON, {
-		// when a delete is performed, run this update
+		// when a delete is performed, update the cache
 		update (cache, { data: { deletePerson } }) {
 			// read ALL_PERSONS
 			const allPersons = cache.readQuery({ query: ALL_PERSONS });

--- a/src/components/pages/People.js
+++ b/src/components/pages/People.js
@@ -1,19 +1,25 @@
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useParams } from 'react-router-dom';
 import PeopleForm from '../forms/PeopleForm';
 import PeopleList from '../lists/PeopleList';
 import { Link, Route, Switch } from 'react-router-dom';
 import { Button } from 'antd';
 import { useMutation, useQuery } from '@apollo/react-hooks';
-import { CREATE_PERSON, DELETE_PERSON } from '../graphql/mutations';
+import { CREATE_PERSON, UPDATE_PERSON, DELETE_PERSON } from '../graphql/mutations';
 import { ALL_PERSONS } from '../graphql/queries';
 
 const People = () => {
+
+	// for pushing user to /form or /form/:id/ routes,
 	const history = useHistory();
 
 	const [
 		createPerson,
 	] = useMutation(CREATE_PERSON);
+
+	const [ 
+		updatePerson,
+	] = useMutation(UPDATE_PERSON);
 
 	const [
 		deletePerson,
@@ -30,13 +36,27 @@ const People = () => {
 			});
 		},
 	});
+
+	// for displaying list of people,
 	const { loading, data } = useQuery(ALL_PERSONS);
 
-	const onSubmit = formData => {
-		console.log('data', formData);
-		createPerson({
-			variables : { newPerson: formData },
-		});
+	const onSubmit = (formData, personId) => {
+		
+		if(personId) {
+			// this is a person being updated
+			updatePerson({
+				variables: { 
+					id: personId,
+					updates: formData
+				 }
+			});
+		}
+		else {
+			// this is a person being created
+			createPerson({
+				variables : { newPerson: formData },
+			});
+		}
 	};
 
 	const onEdit = personId => {

--- a/src/components/pages/People.js
+++ b/src/components/pages/People.js
@@ -7,6 +7,7 @@ import { Button } from 'antd';
 import { useMutation, useQuery } from '@apollo/react-hooks';
 import { CREATE_PERSON, UPDATE_PERSON, DELETE_PERSON } from '../graphql/mutations';
 import { ALL_PERSONS } from '../graphql/queries';
+import { updateAfterPersonChange, updateAfterPersonDelete } from '../graphql/cache';
 
 const People = () => {
 
@@ -21,39 +22,14 @@ const People = () => {
 		updatePerson,
 	] = useMutation(UPDATE_PERSON, {
 		// when an update is performed, update the cache
-		update(cache, { data: { updatePerson } }) {
-			// read ALL_PERSONS
-			const allPersons = cache.readQuery({ query: ALL_PERSONS });
-			console.log('updatePerson', updatePerson);
-			// write update to the cache
-			cache.writeQuery({
-				query: ALL_PERSONS,
-				data: { persons: allPersons.persons.map(person => {
-					// find the person that was updated and
-					// update the cache,
-					if(person.id === updatePerson.id) {
-						return { ...person, ...updatePerson };
-					}
-					return person;
-				}) }
-			});
-		}
+		update: updateAfterPersonChange
 	});
 
 	const [
 		deletePerson,
 	] = useMutation(DELETE_PERSON, {
 		// when a delete is performed, update the cache
-		update (cache, { data: { deletePerson } }) {
-			// read ALL_PERSONS
-			const allPersons = cache.readQuery({ query: ALL_PERSONS });
-
-			// write delete to the cache
-			cache.writeQuery({
-				query : ALL_PERSONS,
-				data  : { persons: allPersons.persons.filter(person => person.id !== deletePerson.id) },
-			});
-		},
+		update: updateAfterPersonDelete,
 	});
 
 	// for displaying list of people,

--- a/src/components/pages/People.js
+++ b/src/components/pages/People.js
@@ -7,7 +7,7 @@ import { Button } from 'antd';
 import { useMutation, useQuery } from '@apollo/react-hooks';
 import { CREATE_PERSON, UPDATE_PERSON, DELETE_PERSON } from '../graphql/mutations';
 import { ALL_PERSONS } from '../graphql/queries';
-import { updateAfterPersonChange, updateAfterPersonDelete } from '../graphql/cache';
+import { updateAfterPersonCreate, updateAfterPersonChange, updateAfterPersonDelete } from '../graphql/cache';
 
 const People = () => {
 
@@ -16,7 +16,10 @@ const People = () => {
 
 	const [
 		createPerson,
-	] = useMutation(CREATE_PERSON);
+	] = useMutation(CREATE_PERSON, {
+		// when a creation is performed, update the cache
+		update: updateAfterPersonCreate
+	});
 
 	const [ 
 		updatePerson,


### PR DESCRIPTION
# Description
The people form can now edit and update a person. Whenever a person mutation is fired (create, update, delete), the Apollo cache also updates.

A new "cache" directory serves as the location for writing cache updates.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
## Change Status

- [x] Complete, but not tested (may need new tests)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
